### PR TITLE
Removed auto retry in favor of user discretion

### DIFF
--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -73,7 +73,7 @@ export class InitCommand extends Command {
     console.log(`${boldWhite}Edit your content:${reset} https://da.live/#/${githubOrg}/${githubRepo}`)
     console.log(`${boldWhite}Manage your config:${reset} https://da.live/sheet#/${githubOrg}/${githubRepo}/configs-stage`)
     console.log(`${boldWhite}Preview your storefront:${reset} https://main--${githubRepo}--${githubOrg}.aem.page/`)
-    console.log(`${boldWhite}Run locally:${reset} "aio commerce:dev"`)
+    console.log(`${boldWhite}Run your storefront locally:${reset} "aio commerce:dev"`)
     if (meshUrl) {
       console.log(`${boldWhite}Try out your API:${reset} ${meshUrl}`)
       console.log(`To check the status of your Mesh, run ${boldWhite}aio api-mesh status${reset}`)

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -17,7 +17,7 @@ import { promptConfirm } from '../../utils/prompt.js'
 import config from '@adobe/aio-lib-core-config'
 import { createRepo, modifyFstab, modifySidekickConfig } from '../../utils/github.js'
 import { initialization } from '../../utils/initialization.js'
-import { createMesh, checkAndRetryMeshUpdate, getMeshDetailsPage, confirmAPIMeshCreation } from '../../utils/mesh.js'
+import { createMesh, getMeshDetailsPage, confirmAPIMeshCreation } from '../../utils/mesh.js'
 
 const reset = '\x1b[0m'
 const boldWhite = '\x1b[1m\x1b[37m'
@@ -65,10 +65,7 @@ export class InitCommand extends Command {
     await previewContent(filePaths)
     await publishContent()
 
-    // TODO: this fails with
-    // 2025-02-04T17:42:36.664Z [commerce:mesh.js] error: TypeError: Cannot read properties of undefined (reading 'id')
-    // at getMeshDetailsPage (aio-cli-plugin-commerce/src/utils/mesh.js:378:35)
-    // const meshDetailsPageURL = getMeshDetailsPage()
+    const meshDetailsPageURL = getMeshDetailsPage()
     const meshUrl = config.get('commerce.datasource.meshUrl')
 
     console.log(`🎉 ${boldWhite}Setup complete!${reset} 🎉`)
@@ -76,16 +73,16 @@ export class InitCommand extends Command {
     console.log(`${boldWhite}Edit your content:${reset} https://da.live/#/${githubOrg}/${githubRepo}`)
     console.log(`${boldWhite}Manage your config:${reset} https://da.live/sheet#/${githubOrg}/${githubRepo}/configs-stage`)
     console.log(`${boldWhite}Preview your storefront:${reset} https://main--${githubRepo}--${githubOrg}.aem.page/`)
-    meshUrl && console.log(`${boldWhite}Try out your API:${reset} ${meshUrl}`)
-    // meshDetailsPageURL && console.log(`${boldWhite}View your Mesh details:${reset} ${meshDetailsPageURL}`)
     console.log(`${boldWhite}Run locally:${reset} "aio commerce:dev"`)
-    console.log('For next steps, including how to customize your storefront and make it your own, check out our docs:\nhttps://experienceleague.adobe.com/developer/commerce/storefront/')
-
-    // if we created a mesh, wait for verification to complete before exiting
-    // TODO: Replace with detached childProcess.
-    if (shouldCreateMesh) {
-      await checkAndRetryMeshUpdate(runAIOCommand)
+    if (meshUrl) {
+      console.log(`${boldWhite}Try out your API:${reset} ${meshUrl}`)
+      console.log(`To check the status of your Mesh, run ${boldWhite}aio api-mesh status${reset}`)
+      console.log(`To update your Mesh, run ${boldWhite}aio api-mesh update mesh_config.json${reset}`)
+      if (meshDetailsPageURL) {
+        meshDetailsPageURL && console.log(`${boldWhite}View your Mesh details:${reset} ${meshDetailsPageURL}`)
+      }
     }
+    console.log('For next steps, including how to customize your storefront and make it your own, check out our docs:\nhttps://experienceleague.adobe.com/developer/commerce/storefront/')
 
     // cleanup
     config.delete('commerce')

--- a/src/commands/commerce/test.js
+++ b/src/commands/commerce/test.js
@@ -9,16 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { Command, Help } from '@oclif/core'
-import { checkAndRetryMeshUpdate } from '../../utils/mesh.js'
+import { Command } from '@oclif/core'
 
 export class TestCommand extends Command {
   async run () {
-    const runAIOCommand = async (command, args) => {
-      return await this.config.runCommand(command, args)
-    }
-    await checkAndRetryMeshUpdate(runAIOCommand)
+    console.log('Just testing!')
   }
 }
 
-TestCommand.description = 'Spin up an Adobe Commerce Storefront on EDS using this CLI tool'
+TestCommand.description = 'A test command'

--- a/src/utils/mesh.js
+++ b/src/utils/mesh.js
@@ -9,7 +9,6 @@ import { promptConfirm } from './prompt.js'
 const aioLogger = Logger('commerce:mesh.js')
 const meshConfigFilePath = path.join('./', 'mesh_config.json')
 
-
 /**
  *
  * @param core
@@ -215,87 +214,12 @@ async function createTempMeshConfigFile (
 }
 
 /**
- * !@deprecated - this function is not used because we felt it beneficial to
- * retain the local mesh config file that was used, incase the user wants to
- * modify and/or use it later.
- */
-// eslint-disable-next-line no-unused-vars
-async function deleteTempMeshConfigFile () {
-  await fsPromise.unlink(meshConfigFilePath)
-}
-
-/**
  *
  */
 export async function confirmAPIMeshCreation () {
   return await promptConfirm(
     'Do you want to create an API Mesh for your Commerce instance?'
   )
-}
-
-/**
- *
- * @param runAIOCommand
- */
-async function updateMesh (runAIOCommand) {
-  aioLogger.debug('Updating API Mesh...')
-  await runAIOCommand('api-mesh:update', [meshConfigFilePath, '-c'])
-  aioLogger.debug('API Mesh updated')
-}
-
-/**
- *
- * @param runAIOCommand
- */
-async function getMeshStatus (runAIOCommand) {
-  aioLogger.debug('Checking API Mesh status...')
-  const { meshStatus } = await runAIOCommand('api-mesh:status', [])
-  aioLogger.debug('API Mesh status: ', meshStatus)
-
-  return meshStatus
-}
-
-/**
- * Function to check the status of the mesh creation and retry if it fails
- *
- * @param {*} runAIOCommand
- */
-export async function checkAndRetryMeshUpdate (runAIOCommand, retries = 2, retryInterval = 60 * 1000) {
-  try {
-    let meshStatus = await getMeshStatus(runAIOCommand)
-    let count = 0
-
-    /**
-     *
-     * Wait 1 minute and if meshStatus is not success, run an update.
-     * Repeat this process for MESH_RETRIES times and then throw an error if meshStatus is still not success
-     *
-     */
-    while (meshStatus !== 'success' && count < retries) {
-      aioLogger.debug(
-        `Mesh creation failed. Retrying... Attempt ${
-            count + 1
-        }/${retries}`
-      )
-      console.log('Retrying API Mesh creation...')
-      await updateMesh(runAIOCommand)
-      await new Promise((resolve) =>
-        setTimeout(resolve, retryInterval)
-      )
-
-      meshStatus = await getMeshStatus(runAIOCommand)
-      count++
-    }
-
-    if (meshStatus !== 'success') {
-      throw new Error('API Mesh creation failed')
-    }
-  } catch (error) {
-    aioLogger.error(error)
-    throw new Error(
-      'API Mesh creation failed, please retry by running "aio api-mesh update mesh_config.json"'
-    )
-  }
 }
 
 /**
@@ -377,7 +301,7 @@ export function getMeshDetailsPage () {
       return `https://developer.adobe.com/console/projects/${orgID}/${projectID}/workspaces/${workspaceID}/details`
     }
   } catch (err) {
-    aioLogger.error(err)
+    aioLogger.debug(err)
 
     return null
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the functionality to check for mesh provisioning and auto retry in case of failures. This PR adds new command line logs to allow the customer to check and re-provision their meshes in case of a failure. This will reduce the complexity involved with retry logic.

## Related Issue

NA

## Motivation and Context

Reducing complexity and avoiding over engineering

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
