### PR TITLE
add flags to allow skipping input

### DIFF
--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -55,7 +55,7 @@ async function getFilePathsFromAem () {
           return data.data.resources
             .filter(resource => !resource.path.startsWith('/draft') && !resource.path.startsWith('/helix-env.json') && !resource.path.startsWith('/sitemap-content.xml'))
             .map(resource => {
-              if (templateRepo === 'citisignal-one' || templateRepo === 'adobe-demo-store') {
+              if (templateRepo === 'citisignal-one' || templateRepo === 'adobe-demo-store' || templateRepo === 'ccdm-demo-store') {
                 // These templates have not published all files, thus we have to use preview urls for content source
                 return `https://main--${templateRepo}--${templateOrg}.aem.page/${resource.path.replace(/^\/+/, '')}`
               } else {

--- a/src/utils/initialization.js
+++ b/src/utils/initialization.js
@@ -34,7 +34,7 @@ export async function initialization (args, flags) {
     org = await promptInput('Enter the GitHub organization under which to create the code repository')
   }
 
-  repo = repo || await promptInput('Enter the GitHub storefront repo name to create (must not exist already):')
+  repo = repo?.split('/')[1] || await promptInput('Enter the GitHub storefront repo name to create (must not exist already):')
 
   if (!org || !repo) {
     throw new Error('❌ Please provide both the github org/name and repo.')

--- a/src/utils/initialization.js
+++ b/src/utils/initialization.js
@@ -24,7 +24,7 @@ export async function initialization (args, flags) {
 'This tool aims to automate the GitHub repository creation, the content source uploading, and the initial content preview.\nIn just a few minutes, you\'ll have your very own storefront codebase as well as an Edge Delivery Services content space ready to go.\nLet\'s get started!')
 
   // GITHUB DESTINATION SELECTION
-  let { repo } = flags
+  let { repo, template } = flags
   let { stdout: org } = await runCommand("gh api user --jq '.login'")
   if (!org) {
     throw new Error('❌ Unable to get github username. Please authenticate first with `gh auth login`".')
@@ -34,9 +34,8 @@ export async function initialization (args, flags) {
     org = await promptInput('Enter the GitHub organization under which to create the code repository')
   }
 
-  if (!repo) {
-    repo = await promptInput('Enter the GitHub storefront repo name to create (must not exist already):')
-  }
+  repo = repo || await promptInput('Enter the GitHub storefront repo name to create (must not exist already):')
+
   if (!org || !repo) {
     throw new Error('❌ Please provide both the github org/name and repo.')
   }
@@ -45,7 +44,8 @@ export async function initialization (args, flags) {
   config.set('commerce.github.repo', repo)
 
   // TEMPLATE SELECTION
-  const template = await promptSelect('Which template would you like to use?', [
+  // TODO: validate template is allowed
+  template = template || await promptSelect('Which template would you like to use?', [
     'adobe-commerce/adobe-demo-store', // ACCS template
     'hlxsites/aem-boilerplate-commerce', // PaaS template
     'adobe-rnd/aem-boilerplate-xcom' // UE Template


### PR DESCRIPTION
Goals:

1) Allow user to skip input steps during CLI and just pass all variables during initial run.
2) Add ability for us to call scaffolder programmatically for certain cases (such as running it 100x via bash script).

Try this:

```
AIO_LOG_LEVEL=debug aio commerce:init --template "adobe-commerce/adobe-demo-store" --skipMesh --repo "YOUR_ORG_OR_USER/YOUR_REPO_NAME" --datasource "https://na1-sandbox.api.commerce.adobe.com/F1psVHfVkXhcQxhqNbCora/graphql"
```

Note:

* If any of `repo` `template` or `datasource` flags are not provided, the cli will go into `initialization` function which requests user input. It will use any values provided (ie just repo, or just template, etc) while requesting values that were not provided.
