### PR TITLE
use new response structure from CCM API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -81,6 +81,7 @@ export class InitCommand extends Command {
 
       const meshDetailsPageURL = getMeshDetailsPage()
       const meshUrl = config.get('commerce.datasource.meshUrl')
+      const adminUrl = config.get('commerce.datasource.admin')
 
       console.log('\n************************************************')
       console.log(`🎉 ${boldWhite}Setup complete!${reset} 🎉\n`)
@@ -88,7 +89,9 @@ export class InitCommand extends Command {
       console.log(`${boldWhite}Edit your content:${reset} https://da.live/#/${githubOrg}/${githubRepo}`)
       console.log(`${boldWhite}Manage your config:${reset} https://da.live/sheet#/${githubOrg}/${githubRepo}/configs-stage`)
       console.log(`${boldWhite}Preview your storefront:${reset} https://main--${githubRepo}--${githubOrg}.aem.page/`)
-      console.log(`${boldWhite}Run your storefront locally:${reset} "aio commerce:dev"`)
+      if (adminUrl) {
+        console.log(`${boldWhite}Access your Commerce Admin:${reset} ${adminUrl}`)
+      }
       if (meshUrl) {
         console.log(`${boldWhite}Try out your API:${reset} ${meshUrl}`)
         console.log(`To check the status of your Mesh, run ${boldWhite}aio api-mesh status${reset}`)

--- a/src/utils/accs.js
+++ b/src/utils/accs.js
@@ -49,6 +49,18 @@ export async function getAndSelectInstances () {
     )
     const urlMatch = choice.match(urlPattern)
     aioLogger.debug('selected', urlMatch[0])
+
+    try {
+      const chosen = resp?.tenants?.find(tenant => tenant.serviceURLs.graphQL === urlMatch[0])
+      if (chosen) {
+        config.set('commerce.datasource.admin', chosen.serviceURLs.admin)
+      } else {
+        // no admin url
+        aioLogger.debug('unable to get admin url')
+      }
+    } catch (e) {
+      aioLogger.debug('unable to get admin url')
+    }
     return urlMatch[0]
   } catch (e) {
     aioLogger.log('Tenant API is not available. Check your aio IMS Org settings and try again.')

--- a/src/utils/accs.js
+++ b/src/utils/accs.js
@@ -40,7 +40,7 @@ export async function getAndSelectInstances () {
     }
 
     const choices = DEFAULT_TENANTS.concat(
-      resp?.tenants?.map(tenant => `${tenant.name}: ${tenant.instanceURL}/graphql`) || []
+      resp?.tenants?.map(tenant => `${tenant.name}: ${tenant.serviceURLs.graphQL}`) || []
     )
 
     const choice = await promptSelect(


### PR DESCRIPTION
Once CCM API updates the response structure, we can use it to properly get the graphql url instead of manually appending /grapql.

we can also use it to do things like give a quick link to the admin backend/