### PR TITLE
Auto publish

### DIFF
--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -77,10 +77,10 @@ export class InitCommand extends Command {
       const filePaths = await uploadStarterContent()
       console.log('⏳ Validating code sync...')
       await codeSyncComplete()
-      console.log('⏳ Previewing some necessary files...')
+      console.log('⏳ Previewing your content files so your site will be accessible at *.aem.page')
       await previewContent(filePaths)
-      console.log('⏳ Publishing some necessary files...')
-      await publishContent()
+      console.log('⏳ Publishing your content files so your site will be accessible at *.aem.live')
+      await publishContent(filePaths)
 
       const meshUrl = config.get('commerce.datasource.meshUrl')
       const adminUrl = config.get('commerce.datasource.admin')

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -77,9 +77,9 @@ export class InitCommand extends Command {
       const filePaths = await uploadStarterContent()
       console.log('⏳ Validating code sync...')
       await codeSyncComplete()
-      console.log('⏳ Previewing your content files so your site will be accessible at *.aem.page')
+      console.log('⏳ Previewing your content files...')
       await previewContent(filePaths)
-      console.log('⏳ Publishing your content files so your site will be accessible at *.aem.live')
+      console.log('⏳ Publishing your content files...')
       await publishContent(filePaths)
 
       const meshUrl = config.get('commerce.datasource.meshUrl')

--- a/src/utils/fetchWithRetry.js
+++ b/src/utils/fetchWithRetry.js
@@ -1,21 +1,31 @@
+import Logger from '@adobe/aio-lib-core-logging'
+const aioLogger = Logger('commerce:fetchWithRetry.js')
+
 /**
  *
- * @param url
- * @param options
- * @param retries
+ * @param {string} url [string] the url to fetch
+ * @param {object} options fetch options
+ * @param {Function} callback function receives data from response and can return true to stop retrying. Defaults to a function that returns true.
+ * @param {number} interval delay between retries in milliseconds defaults to 1000
+ * @param {number} maxRetries number of retries defaults to 10
  */
-export async function fetchWithRetry (url, options, retries = 3) {
-  for (let i = 0; i < retries; i++) {
-    try {
-      const response = await fetch(url, options)
-      if (response.ok) {
-        return response
+export async function fetchWithRetry (url, options = {}, callback = () => true, interval = 1000, maxRetries = 10) {
+  let retryCount = 0
+  while (retryCount <= maxRetries) {
+    const res = await fetch(url, options)
+    if (res.ok) {
+      const data = await res.json()
+      aioLogger.debug(data)
+      const isComplete = await callback(data)
+      if (isComplete) {
+        return
       }
-      throw new Error('Fetch failed')
-    } catch (error) {
-      if (i === retries - 1) {
-        throw error
-      }
+    } else {
+      aioLogger.debug(`fetch failed, retrying (${retryCount + 1}/${maxRetries})`, res)
     }
+
+    await new Promise(resolve => setTimeout(resolve, interval))
+    retryCount++
   }
+  throw new Error('fetch failed after max retries')
 }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -40,7 +40,7 @@ export async function createRepo () {
  */
 export async function modifyFstab () {
   const { org, repo } = config.get('commerce.github')
-  const { org: templateOrg, repo: templateRepo } = config.get('commerce.template')
+  const { repo: templateRepo } = config.get('commerce.template')
   let repoReady = false
   let attempts = 0
   while (!repoReady && attempts++ <= 10) {

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -75,7 +75,7 @@ export async function previewContent (files) {
 }
 
 /**
- * For DA Live Preview, we must publish some files. This must be done AFTER preview.
+ *
  * https://www.aem.live/docs/admin.html#tag/publish/operation/bulkPublish
  * @param files
  */

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -2,6 +2,34 @@ import config from '@adobe/aio-lib-core-config'
 import Logger from '@adobe/aio-lib-core-logging'
 const aioLogger = Logger('commerce:preview.js')
 
+/**
+ * TODO: extract to other util file and use everywhere we have some fetch + callback + retry needs
+ * @param detailsUrl
+ * @param fileCount
+ * @param callback
+ * @param interval
+ * @param maxRetries
+ */
+export async function waitForComplete (detailsUrl, callback, interval = 1000, maxRetries = 10) {
+  let retryCount = 0
+  while (retryCount <= maxRetries) {
+    const res = await fetch(detailsUrl)
+    if (res.ok) {
+      const data = await res.json()
+      aioLogger.debug(data)
+      const isComplete = await callback(data)
+      if (isComplete) {
+        return
+      }
+    } else {
+      aioLogger.debug(`details fetch failed, retrying (${retryCount + 1}/${maxRetries})`, res)
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval))
+    retryCount++
+  }
+}
+
 // TODO: DRY - only diff for the preview/publish functions is the API url and log detail (use of term preview vs publish).
 // we should refactor
 /**
@@ -33,7 +61,11 @@ export async function previewContent (files) {
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('✅ Started batch content preview job.')
-      await waitForComplete(detailsUrl, previewFiles.length)
+      await waitForComplete(detailsUrl, (data) => {
+        return data.data.phase === 'completed' &&
+        data.progress.processed === previewFiles.length &&
+        data.progress.success === previewFiles.length
+      })
       console.log('✅ Batch content preview job completed successfully.')
     }
   } catch (error) {
@@ -42,35 +74,6 @@ export async function previewContent (files) {
   }
 }
 
-/**
- *
- * @param detailsUrl
- * @param fileCount
- * @param interval
- * @param maxRetries
- */
-export async function waitForComplete (detailsUrl, fileCount, interval = 1000, maxRetries = 10) {
-  let retryCount = 0
-  while (retryCount <= maxRetries) {
-    const res = await fetch(detailsUrl)
-    if (res.ok) {
-      const data = await res.json()
-      const isComplete =
-        data.data.phase === 'completed' &&
-        data.progress.processed === fileCount &&
-        data.progress.success === fileCount
-      aioLogger.debug(data)
-      if (isComplete) {
-        return
-      }
-    } else {
-      aioLogger.debug(`details fetch failed, retrying (${retryCount + 1}/${maxRetries})`, res)
-    }
-
-    await new Promise(resolve => setTimeout(resolve, interval))
-    retryCount++
-  }
-}
 /**
  * For DA Live Preview, we must publish some files. This must be done AFTER preview.
  * https://www.aem.live/docs/admin.html#tag/publish/operation/bulkPublish
@@ -100,7 +103,11 @@ export async function publishContent (files) {
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('✅ Started batch content publish job.')
-      await waitForComplete(detailsUrl, publishFiles.length)
+      await waitForComplete(detailsUrl, (data) => {
+        return data.data.phase === 'completed' &&
+        data.progress.processed === publishFiles.length &&
+        data.progress.success === publishFiles.length
+      })
       console.log('✅ Batch content publish job completed successfully.')
     }
   } catch (error) {

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -1,35 +1,7 @@
 import config from '@adobe/aio-lib-core-config'
 import Logger from '@adobe/aio-lib-core-logging'
+import { fetchWithRetry } from './fetchWithRetry'
 const aioLogger = Logger('commerce:preview.js')
-
-/**
- * TODO: extract to other util file and use everywhere we have some fetch + callback + retry needs
- * @param detailsUrl
- * @param fileCount
- * @param callback
- * @param interval
- * @param maxRetries
- */
-export async function waitForComplete (detailsUrl, callback, interval = 1000, maxRetries = 10) {
-  let retryCount = 0
-  while (retryCount <= maxRetries) {
-    const res = await fetch(detailsUrl)
-    if (res.ok) {
-      const data = await res.json()
-      aioLogger.debug(data)
-      const isComplete = await callback(data)
-      if (isComplete) {
-        return
-      }
-    } else {
-      aioLogger.debug(`details fetch failed, retrying (${retryCount + 1}/${maxRetries})`, res)
-    }
-
-    await new Promise(resolve => setTimeout(resolve, interval))
-    retryCount++
-  }
-  throw new Error('fetch failed after max retries')
-}
 
 // TODO: DRY - only diff for the preview/publish functions is the API url and log detail (use of term preview vs publish).
 // we should refactor
@@ -62,10 +34,10 @@ export async function previewContent (files) {
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('⏳ Started batch content preview job.')
-      await waitForComplete(detailsUrl, (data) => {
+      await fetchWithRetry(detailsUrl, {}, (data) => {
         return data.data.phase === 'completed' &&
-        data.progress.processed === previewFiles.length &&
-        data.progress.success === previewFiles.length
+          data.progress.processed === previewFiles.length &&
+          data.progress.success === previewFiles.length
       })
       console.log('✅ Batch content preview job completed successfully.')
     }
@@ -104,10 +76,10 @@ export async function publishContent (files) {
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('⏳ Started batch content publish job.')
-      await waitForComplete(detailsUrl, (data) => {
+      await fetchWithRetry(detailsUrl, {}, (data) => {
         return data.data.phase === 'completed' &&
-        data.progress.processed === publishFiles.length &&
-        data.progress.success === publishFiles.length
+          data.progress.processed === publishFiles.length &&
+          data.progress.success === publishFiles.length
       })
       console.log('✅ Batch content publish job completed successfully.')
     }

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -60,7 +60,7 @@ export async function previewContent (files) {
       const resJson = await res.json()
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
-      console.log('✅ Started batch content preview job.')
+      console.log('⏳ Started batch content preview job.')
       await waitForComplete(detailsUrl, (data) => {
         return data.data.phase === 'completed' &&
         data.progress.processed === previewFiles.length &&
@@ -102,7 +102,7 @@ export async function publishContent (files) {
       const resJson = await res.json()
       const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
-      console.log('✅ Started batch content publish job.')
+      console.log('⏳ Started batch content publish job.')
       await waitForComplete(detailsUrl, (data) => {
         return data.data.phase === 'completed' &&
         data.progress.processed === publishFiles.length &&

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -29,7 +29,8 @@ export async function previewContent (files) {
     if (res.status !== 202) {
       console.log(`❌ Had issues previewing files. Please try the CLI command again with AIO_LOG_LEVEL=debug for more information, or try manually publishing your content from the document authoring page at https://da.live/#/${org}/${repo}`)
     } else {
-      const detailsUrl = `${res.links.self}/details`
+      const resJson = await res.json()
+      const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('✅ Started batch content preview job.')
       await waitForComplete(detailsUrl, previewFiles.length)
@@ -95,7 +96,8 @@ export async function publishContent (files) {
     if (res.status !== 202) {
       console.log(`❌ Had issues publishing files. Please try the CLI command again with AIO_LOG_LEVEL=debug for more information, or try manually publishing your content from the document authoring page at https://da.live/#/${org}/${repo}`)
     } else {
-      const detailsUrl = `${res.links.self}/details`
+      const resJson = await res.json()
+      const detailsUrl = `${resJson.links.self}/details`
       aioLogger.debug(detailsUrl)
       console.log('✅ Started batch content publish job.')
       await waitForComplete(detailsUrl, publishFiles.length)

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -12,10 +12,10 @@ const aioLogger = Logger('commerce:preview.js')
 export async function previewContent (files) {
   const { org, repo } = config.get('commerce.github')
   if (!org || !repo) throw new Error('Missing Github Org and Repo')
+  const url = new URL(`https://admin.hlx.page/preview/${org}/${repo}/main/*`)
   try {
     const previewFiles = files.map(file => new URL(file).pathname)
     aioLogger.debug(previewFiles)
-    const url = new URL(`https://admin.hlx.page/preview/${org}/${repo}/main/*`)
     const res = await fetch(url, {
       method: 'POST',
       headers: {
@@ -37,32 +37,25 @@ export async function previewContent (files) {
   }
 }
 
-const filesToPublish = [
-  '/configs.json',
-  '/placeholders.json',
-  // TODO: nav, footer, and mini-cart are only necessary for base boilerplate, not citisignal. Add logic to conditionally determine whether we need to publish these at all. We may need to find if there are any citisignal files which need publishing too.
-  '/nav',
-  '/footer',
-  '/mini-cart'
-]
-
 /**
  * For DA Live Preview, we must publish some files. This must be done AFTER preview.
  * https://www.aem.live/docs/admin.html#tag/publish/operation/bulkPublish
+ * @param files
  */
-export async function publishContent () {
+export async function publishContent (files) {
   const { org, repo } = config.get('commerce.github')
   if (!org || !repo) throw new Error('Missing Github Org and Repo')
   const url = new URL(`https://admin.hlx.page/live/${org}/${repo}/main/*`)
-
   try {
+    const publishFiles = files.map(file => new URL(file).pathname)
+    aioLogger.debug(publishFiles)
     const res = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        paths: [...filesToPublish]
+        paths: [...publishFiles]
       })
     })
     if (res.status !== 202) {

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -28,6 +28,7 @@ export async function waitForComplete (detailsUrl, callback, interval = 1000, ma
     await new Promise(resolve => setTimeout(resolve, interval))
     retryCount++
   }
+  throw new Error('fetch failed after max retries')
 }
 
 // TODO: DRY - only diff for the preview/publish functions is the API url and log detail (use of term preview vs publish).

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -34,7 +34,7 @@ export async function waitForComplete (detailsUrl, callback, interval = 1000, ma
 // we should refactor
 /**
  * https://www.aem.live/docs/admin.html#tag/preview/operation/bulkPreview
- * // TODO: update to take paths, instead of full urls
+ * TODO: update to take paths, instead of full urls
  * @param files urls whose paths we will preview
  */
 export async function previewContent (files) {

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -1,6 +1,6 @@
 import config from '@adobe/aio-lib-core-config'
 import Logger from '@adobe/aio-lib-core-logging'
-import { fetchWithRetry } from './fetchWithRetry'
+import { fetchWithRetry } from './fetchWithRetry.js'
 const aioLogger = Logger('commerce:preview.js')
 
 // TODO: DRY - only diff for the preview/publish functions is the API url and log detail (use of term preview vs publish).


### PR DESCRIPTION
- bulkPreview api is async
- you cannot publish until your files are previewed (as publish is just copying previewed files)
- so we add logic to wait for preview to complete, before publishing.