### PR TITLE
feature: copy from published source and initialize da library config

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,6 @@ EXAMPLES
 ```
 <!-- commandsstop -->
 
-## Contributing
-
-Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
-
 ## Local Development
 
 ```sh
@@ -161,6 +157,13 @@ cd aio-cli-plugin-commerce
 npm install
 aio plugins:link commerce
 ```
+
+## Templates
+
+The requirements for adding or using a template (source site) are:
+
+* The source site github repo is a "template" repo.
+* The source site produces a `full-index.json` (see [this](https://admin.hlx.page/config/adobe-commerce/sites/boilerplate/content/query.yaml) for example).
 
 ## Logging
 
@@ -171,6 +174,10 @@ Use `AIO_LOG_LEVEL=debug|verbose|info|warn|error <command>` to see full logs.
 ```sh
 AIO_LOG_LEVEL=debug aio commerce:init
 ```
+
+## Contributing
+
+Contributions are welcomed! Read the [Contributing Guide](CONTRIBUTING.md) for more information.
 
 ## Licensing
 

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -75,10 +75,12 @@ export class InitCommand extends Command {
         await codeSyncComplete(githubOrg, githubRepo)
       }
       const filePaths = await uploadStarterContent()
+      // Certain files are specific to da, and should not be previewed/published.
+      const filePathsWithoutPrivate = filePaths.filter(file => !file.startsWith('/.da/'))
       console.log('⏳ Previewing your content files...')
-      await previewContent(filePaths)
+      await previewContent(filePathsWithoutPrivate)
       console.log('⏳ Publishing your content files...')
-      await publishContent(filePaths)
+      await publishContent(filePathsWithoutPrivate)
 
       const meshUrl = config.get('commerce.datasource.meshUrl')
       const adminUrl = config.get('commerce.datasource.admin')

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -88,8 +88,8 @@ export class InitCommand extends Command {
       console.log('\n************************************************')
       console.log(`🎉 ${boldWhite}Setup complete!${reset} 🎉\n`)
       console.log(`${boldWhite}Customize your code:${reset} https://github.com/${githubOrg}/${githubRepo}`)
+      console.log(`${boldWhite}Manage your Commerce config:${reset} https://github.com/${githubOrg}/${githubRepo}/blob/main/config.json`)
       console.log(`${boldWhite}Edit your content:${reset} https://da.live/#/${githubOrg}/${githubRepo}`)
-      console.log(`${boldWhite}Manage your config:${reset} https://da.live/sheet#/${githubOrg}/${githubRepo}/configs-stage`)
       console.log(`${boldWhite}Preview your storefront:${reset} https://main--${githubRepo}--${githubOrg}.aem.page/`)
       if (adminUrl) {
         console.log(`${boldWhite}Access your Commerce Admin:${reset} ${adminUrl}`)

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -51,11 +51,35 @@ export function modifyConfig (configSource) {
   return JSON.stringify(configJson)
 }
 
-const generateDaSiteConfig = () => {
+/**
+ * Modifies block library config and replaces references with new org/site
+ * @param configSource
+ */
+export function modifyDaBlockLibraryConfig (configSource) {
+  const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
+  // convert source to json if a string
+  let configJson = configSource
+  if (typeof configSource === 'string') {
+    configJson = JSON.parse(configSource)
+  }
+  aioLogger.debug('pre-modificaiton block config:', JSON.stringify(configJson, null, 2))
+  configJson.data.data = configJson.data.data.map(item => {
+    item.path = item.path.replace('adobe-commerce/boilerplate', `${gitOrg}/${gitRepo}`)
+    return item
+  })
+
+  aioLogger.debug('modified block config:', JSON.stringify(configJson, null, 2))
+  return JSON.stringify(configJson)
+}
+
+/**
+ * Creates a da site config for DA library
+ */
+export function createDaSiteConfig () {
   const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
   const basePath = `https://content.da.live/${gitOrg}/${gitRepo}/.da/library`
 
-  return {
+  const configJson = {
     data: {
       total: 1,
       limit: 1,
@@ -85,13 +109,6 @@ const generateDaSiteConfig = () => {
     ':version': 3,
     ':type': 'multi-sheet'
   }
-}
-
-/**
- * Creates a da site config for DA library
- */
-export function createDaSiteConfig () {
-  const configJson = generateDaSiteConfig()
   aioLogger.debug('created da site config:', JSON.stringify(configJson, null, 2))
   return JSON.stringify(configJson)
 }

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -51,16 +51,57 @@ export function modifyConfig (configSource) {
   return JSON.stringify(configJson)
 }
 
-export function modifyDaConfig (configSource) {
+const DA_SITE_CONFIG = {
+  data: {
+    total: 1,
+    limit: 1,
+    offset: 0,
+    data: [
+      {}
+    ],
+    ':colWidths': []
+  },
+  library: {
+    total: 2,
+    limit: 2,
+    offset: 0,
+    data: [
+      {
+        title: 'Blocks',
+        path: 'https://content.da.live/adobe-commerce/boilerplate/.da/library/blocks.json',
+        format: ''
+      },
+      {
+        title: 'Icons',
+        path: 'https://content.da.live/adobe-commerce/boilerplate/.da/library/icons.json',
+        format: ':<content>:'
+      }
+    ],
+    ':colWidths': [
+      75,
+      500,
+      100
+    ]
+  },
+  ':names': [
+    'data',
+    'library'
+  ],
+  ':version': 3,
+  ':type': 'multi-sheet'
+}
+
+/**
+ * Creates a da site config for DA library
+ *
+ */
+export function createDaSiteConfig () {
   // get dest org/site
   const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
-  let configJson = configSource
-  if (typeof configSource === 'string') {
-    configJson = JSON.parse(configSource)
-  }
 
-  configJson.data = configJson?.data.map((item) => {
-    item.value.replace('adobe-commerce/boilerplate', `${gitOrg}/${gitRepo}`)
+  const configJson = DA_SITE_CONFIG
+  configJson.library.data = configJson.library.data.map((item) => {
+    item.path = item.path.replace('adobe-commerce/boilerplate', `${gitOrg}/${gitRepo}`)
     return item
   })
 

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -50,3 +50,20 @@ export function modifyConfig (configSource) {
   aioLogger.debug('modified config:', JSON.stringify(configJson, null, 2))
   return JSON.stringify(configJson)
 }
+
+export function modifyDaConfig (configSource) {
+  // get dest org/site
+  const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
+  let configJson = configSource
+  if (typeof configSource === 'string') {
+    configJson = JSON.parse(configSource)
+  }
+
+  configJson.data = configJson?.data.map((item) => {
+    item.value.replace('adobe-commerce/boilerplate', `${gitOrg}/${gitRepo}`)
+    return item
+  })
+
+  aioLogger.debug('modified .da/config:', JSON.stringify(configJson, null, 2))
+  return JSON.stringify(configJson)
+}

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -51,60 +51,47 @@ export function modifyConfig (configSource) {
   return JSON.stringify(configJson)
 }
 
-const DA_SITE_CONFIG = {
-  data: {
-    total: 1,
-    limit: 1,
-    offset: 0,
-    data: [
-      {}
-    ],
-    ':colWidths': []
-  },
-  library: {
-    total: 2,
-    limit: 2,
-    offset: 0,
-    data: [
-      {
-        title: 'Blocks',
-        path: 'https://content.da.live/adobe-commerce/boilerplate/.da/library/blocks.json',
-        format: ''
-      },
-      {
-        title: 'Icons',
-        path: 'https://content.da.live/adobe-commerce/boilerplate/.da/library/icons.json',
-        format: ':<content>:'
-      }
-    ],
-    ':colWidths': [
-      75,
-      500,
-      100
-    ]
-  },
-  ':names': [
-    'data',
-    'library'
-  ],
-  ':version': 3,
-  ':type': 'multi-sheet'
+const generateDaSiteConfig = () => {
+  const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
+  const basePath = `https://content.da.live/${gitOrg}/${gitRepo}/.da/library`
+
+  return {
+    data: {
+      total: 1,
+      limit: 1,
+      offset: 0,
+      data: [{}],
+      ':colWidths': []
+    },
+    library: {
+      total: 2,
+      limit: 2,
+      offset: 0,
+      data: [
+        {
+          title: 'Blocks',
+          path: `${basePath}/blocks.json`,
+          format: ''
+        },
+        {
+          title: 'Icons',
+          path: `${basePath}/icons.json`,
+          format: ':<content>:'
+        }
+      ],
+      ':colWidths': [75, 500, 100]
+    },
+    ':names': ['data', 'library'],
+    ':version': 3,
+    ':type': 'multi-sheet'
+  }
 }
 
 /**
  * Creates a da site config for DA library
- *
  */
 export function createDaSiteConfig () {
-  // get dest org/site
-  const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
-
-  const configJson = DA_SITE_CONFIG
-  configJson.library.data = configJson.library.data.map((item) => {
-    item.path = item.path.replace('adobe-commerce/boilerplate', `${gitOrg}/${gitRepo}`)
-    return item
-  })
-
+  const configJson = generateDaSiteConfig()
   aioLogger.debug('created da site config:', JSON.stringify(configJson, null, 2))
   return JSON.stringify(configJson)
 }

--- a/src/utils/configs.js
+++ b/src/utils/configs.js
@@ -105,6 +105,6 @@ export function createDaSiteConfig () {
     return item
   })
 
-  aioLogger.debug('modified .da/config:', JSON.stringify(configJson, null, 2))
+  aioLogger.debug('created da site config:', JSON.stringify(configJson, null, 2))
   return JSON.stringify(configJson)
 }

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -36,14 +36,7 @@ async function getFilePathsFromAem () {
     aioLogger.debug(`No paths - does this exist? ${idxUrl}`)
   }
 
-  return [
-    ...paths,
-    // Also copy placeholders, since it is not in the full-index.
-    '/placeholders.json'
-    // TODO: do we need metadata or other files not in the index?
-    // '/metadata.json',
-    // '/products/default/metadata.json'
-  ]
+  return paths
 }
 
 /**

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -71,11 +71,19 @@ async function getFilePathsFromAem () {
         if (data.state === 'stopped') {
           return data.data.resources
             .filter(resource =>
-              !resource.path.startsWith('/draft') &&
+              // TODO: Use `full-index` from boilerplate, rather than excluding by list.
+              // See https://main--aem-boilerplate-commerce--hlxsites.aem.live/full-index.json for example.
+              // paths that should be generated anew
               !resource.path.startsWith('/full-index.json') &&
               !resource.path.startsWith('/helix-env.json') &&
               !resource.path.startsWith('/sitemap-content.xml') &&
-              !resource.path.startsWith('/products-ssg')
+              // paths that should not be copied
+              !resource.path.startsWith('/draft') &&
+              // paths for byom
+              !resource.path.startsWith('/products-ssg') &&
+              !resource.path.startsWith('/products-byom') &&
+              // paths that Mark needs to test GSC
+              !resource.path.startsWith('/structured-data')
             )
             .map(resource => {
               if (templateRepo === 'citisignal-one' || templateRepo === 'adobe-demo-store' || templateRepo === 'ccdm-demo-store') {

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -124,7 +124,7 @@ async function uploadFilesToDA (files) {
  * If the file  url ends in an extension, the extension is used.
  * Otherwise the last part of the path is used as the filename + .md
  *
- * @param {string} contentUrl url representation of the resource, from Helix bulkStatus API
+ * @param {string} contentUrl url or path of the resource
  * @returns {string} the content file path, ending in .md, index.md, or .json
  */
 function getContentFilePath (contentUrl) {

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -1,5 +1,5 @@
 import { getAemHtml } from './importer.js'
-import { modifyConfig } from './configs.js'
+import { modifyConfig, modifyDaConfig } from './configs.js'
 import { fetchWithRetry } from './fetchWithRetry.js'
 import Logger from '@adobe/aio-lib-core-logging'
 import config from '@adobe/aio-lib-core-config'
@@ -57,6 +57,8 @@ async function getBlob (text, pathname) {
   let content = text
   if (ext !== 'json') {
     content = await getAemHtml(text)
+  } else if (pathname.includes('/.da/config')) {
+    content = modifyDaConfig(text)
   } else if (['/configs.json', '/configs-stage.json', '/configs-dev.json'].includes(pathname)) {
     // conditional specifically for helix 4 storefront config file (adobe-demo-store, ccdm-demo-store)
     content = modifyConfig(text)

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -1,5 +1,5 @@
 import { getAemHtml } from './importer.js'
-import { modifyConfig, createDaSiteConfig } from './configs.js'
+import { modifyConfig, createDaSiteConfig, modifyDaBlockLibraryConfig } from './configs.js'
 import { fetchWithRetry } from './fetchWithRetry.js'
 import Logger from '@adobe/aio-lib-core-logging'
 import config from '@adobe/aio-lib-core-config'
@@ -68,6 +68,8 @@ async function getBlob (text, pathname) {
   let content = text
   if (ext !== 'json') {
     content = await getAemHtml(text)
+  } else if (pathname === '/.da/library/blocks.json') {
+    content = modifyDaBlockLibraryConfig(text)
   } else if (['/configs.json', '/configs-stage.json', '/configs-dev.json'].includes(pathname)) {
     // conditional specifically for helix 4 storefront config file (adobe-demo-store, ccdm-demo-store)
     content = modifyConfig(text)

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -17,13 +17,13 @@ export async function uploadStarterContent () {
   const filePaths = await getFilePathsFromAem()
   console.log(`⏳ Cloning ${filePaths.length} content documents from source boilerplate`)
   await uploadFilesToDA(filePaths)
-  await uploadDaLibraryConfig()
+  await uploadDaSiteConfig()
   // TODO: Trim out failed uploads. Context: If files fail to upload, then we
   // don't want to preview them later (this return array is iterated over for previews)
   return filePaths
 }
 
-async function uploadDaLibraryConfig () {
+async function uploadDaSiteConfig () {
   const { org: gitOrg, repo: gitRepo } = config.get('commerce.github')
   const content = createDaSiteConfig()
   const formData = new FormData()
@@ -31,10 +31,7 @@ async function uploadDaLibraryConfig () {
   const fileDaUrl = `https://admin.da.live/config/${gitOrg}/${gitRepo}`
   await fetchWithRetry(fileDaUrl, {
     method: 'PUT',
-    body: formData,
-    headers: {
-      'cache-control': 'no-cache'
-    }
+    body: formData
   })
 }
 /**

--- a/src/utils/fetchWithRetry.js
+++ b/src/utils/fetchWithRetry.js
@@ -6,10 +6,10 @@ const aioLogger = Logger('commerce:fetchWithRetry.js')
  * @param {string} url [string] the url to fetch
  * @param {object} options fetch options
  * @param {Function} callback function receives data from response and can return true to stop retrying. Defaults to a function that returns true.
- * @param {number} interval delay between retries in milliseconds defaults to 1000
+ * @param {number} interval delay between retries in milliseconds defaults to 5000
  * @param {number} maxRetries number of retries defaults to 10
  */
-export async function fetchWithRetry (url, options = {}, callback = () => true, interval = 1000, maxRetries = 10) {
+export async function fetchWithRetry (url, options = {}, callback = () => true, interval = 5000, maxRetries = 10) {
   let retryCount = 0
   while (retryCount <= maxRetries) {
     const res = await fetch(url, options)

--- a/src/utils/openBrowser.js
+++ b/src/utils/openBrowser.js
@@ -34,7 +34,7 @@ async function openBrowser (url) {
     await execPromise(command)
   } catch (error) {
     if (error) {
-      aioLogger.warn('Failed to open browser, make sure you install the code-sync bot at https://github.com/apps/aem-code-sync/installations/select_target')
+      aioLogger.warn('Failed to open browser.')
       aioLogger.debug(error)
     }
   }

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -7,15 +7,13 @@ const aioLogger = Logger('commerce:preview.js')
 // we should refactor
 /**
  * https://www.aem.live/docs/admin.html#tag/preview/operation/bulkPreview
- * TODO: update to take paths, instead of full urls
- * @param files urls whose paths we will preview
+ * @param previewFiles urls whose paths we will preview
  */
-export async function previewContent (files) {
+export async function previewContent (previewFiles) {
   const { org, repo } = config.get('commerce.github')
   if (!org || !repo) throw new Error('Missing Github Org and Repo')
   const url = new URL(`https://admin.hlx.page/preview/${org}/${repo}/main/*`)
   try {
-    const previewFiles = files.map(file => new URL(file).pathname)
     aioLogger.debug(previewFiles)
     const res = await fetch(url, {
       method: 'POST',
@@ -49,14 +47,13 @@ export async function previewContent (files) {
 /**
  *
  * https://www.aem.live/docs/admin.html#tag/publish/operation/bulkPublish
- * @param files
+ * @param publishFiles urls whose paths we will preview
  */
-export async function publishContent (files) {
+export async function publishContent (publishFiles) {
   const { org, repo } = config.get('commerce.github')
   if (!org || !repo) throw new Error('Missing Github Org and Repo')
   const url = new URL(`https://admin.hlx.page/live/${org}/${repo}/main/*`)
   try {
-    const publishFiles = files.map(file => new URL(file).pathname)
     aioLogger.debug(publishFiles)
     const res = await fetch(url, {
       method: 'POST',


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/USF-2332

Right now we just use bulk status to get the list of what to copy, but we should instead only use values in [full-index](https://main--aem-boilerplate-commerce--hlxsites.aem.live/full-index.json) generated by a template. This will speed up the CLI and allow us to work unauthenticated, even if source is protected, so long as the full-index is generated.

Also in this PR is a change which provides a working DA library integration (.da/library, da site config, etc). It does this by copying the source .da/library, and generates a da site config.

You can test with `aio commerce init --skipGit` since git repo is not relevant here, just output content. Try with adobe-demo-store, ccdm-demo-store, and aem-boilerplate-commerce, to ensure all 3 create functional sites.

TODO:
- [x] Add full-index generation to adobe-demo-store and ccdm-demo-store DO NOT MERGE UNTIL THIS IS DONE
- [x] Replace logic for bulkStatus path list with using full-index.json output

Closes #25 