### PR TITLE
fix: throw on runcommand error, and double check that repo exists after gh repo create

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install gh
 gh auth login
 ```
 
-❗ The Github account used by the CLI must have permission to create repositories and install Github Applications on that repository.
+❗ The Github account used by the CLI must have permission to create repositories (_write access_) and install Github Applications on that repository.
 
 ### Mesh Prerequisites
 

--- a/src/commands/commerce/init.js
+++ b/src/commands/commerce/init.js
@@ -119,7 +119,7 @@ export class InitCommand extends Command {
       console.log('************************************************\n')
 
       aioLogger.error(error)
-      throw new Error('❌ Setup failed. Please try again.')
+      throw new Error('Setup failed. Please try again.')
     }
   }
 }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -39,6 +39,7 @@ export async function createRepo (githubOrg, githubRepo, templateOrg, templateRe
     await runCommand(`gh repo create ${githubOrg}/${githubRepo} --template ${templateOrg}/${templateRepo} --public`)
 
     // Wait for repo creation to complete
+    // TODO figure out how to create the commits in proper order without having a timeout or delay.
     await new Promise(resolve => {
       setTimeout(() => resolve(), 5000)
     })

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -24,6 +24,8 @@ export async function createRepo (githubOrg, githubRepo, templateOrg, templateRe
     await new Promise(resolve => {
       setTimeout(() => resolve(), 5000)
     })
+    // If it still does not exist, this should throw.
+    await runCommand(`gh api repos/${githubOrg}/${githubRepo}`)
     console.log(`✅ Created code repository at https://github.com/${githubOrg}/${githubRepo} from template ${templateOrg}/${templateRepo}`)
     await modifyFstab(githubOrg, githubRepo, templateRepo)
     await modifySidekickConfig(githubOrg, githubRepo)

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -14,8 +14,9 @@ const aioLogger = Logger('commerce:github.js')
 export async function createRepo (githubOrg, githubRepo, templateOrg, templateRepo) {
   // Check if the repository already exists
   const cmdResult = await runCommand(`gh api repos/${githubOrg}/${githubRepo}`)
-  if (cmdResult?.stdout) { // if not exist, will throw and return 404.
-    console.error(`❌ Skipping. Cannot create repository that already exists: ${githubOrg}/${githubRepo}`)
+  if (cmdResult?.stdout) {
+    console.error(`❌ Cannot create repository that already exists: ${githubOrg}/${githubRepo}`)
+    throw new Error(`Cannot create a repository that already exists: ${githubOrg}/${githubRepo}`)
   } else {
     // If the repository does not exist, proceed with "create"
     await runCommand(`gh repo create ${githubOrg}/${githubRepo} --template ${templateOrg}/${templateRepo} --public`)

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -38,8 +38,9 @@ export async function createRepo (githubOrg, githubRepo, templateOrg, templateRe
     // If we get here, we have access to the org and the repo doesn't exist
     await runCommand(`gh repo create ${githubOrg}/${githubRepo} --template ${templateOrg}/${templateRepo} --public`)
 
-    // Wait for repo creation to complete
+    // without timeout the commits are all out of order for some reason, and "initial commit" is the last, so fstab and other things are wiped although the appear in commit history
     // TODO figure out how to create the commits in proper order without having a timeout or delay.
+    // Wait for repo creation to complete
     await new Promise(resolve => {
       setTimeout(() => resolve(), 5000)
     })

--- a/src/utils/initialization.js
+++ b/src/utils/initialization.js
@@ -69,13 +69,15 @@ Now, let's get started!\n`)
   config.set('commerce.github.repo', repo)
 
   // TEMPLATE SELECTION
-  template = template || await promptSelect('Which template would you like to use?', [
-    'adobe-commerce/adobe-demo-store', // ACCS template
-    // 'adobe-commerce/ccdm-demo-store', // ACO template
-    'hlxsites/aem-boilerplate-commerce' // template
-    // 'adobe-rnd/aem-boilerplate-xcom' // UE Template
-    // 'aabsites/citisignal' // TODO: Cannot use citisignal until we resolve how to use templates that use config service as some core files are missing https://magento.slack.com/archives/C085R48U3R7/p1738785011567519
-  ])
+  // Allow user to pass template flag, or default to boilerplate
+  template = template || 'hlxsites/aem-boilerplate-commerce'
+  // template = template || await promptSelect('Which template would you like to use?', [
+  //   'adobe-commerce/adobe-demo-store', // ACCS template
+  //   'adobe-commerce/ccdm-demo-store', // ACO template
+  //   'hlxsites/aem-boilerplate-commerce' // template
+  //   // 'adobe-rnd/aem-boilerplate-xcom' // UE Template
+  //   // 'aabsites/citisignal' // TODO: Cannot use citisignal until we resolve how to use templates that use config service as some core files are missing https://magento.slack.com/archives/C085R48U3R7/p1738785011567519
+  // ])
   config.set('commerce.template.org', template.split('/')[0])
   config.set('commerce.template.repo', template.split('/')[1])
 

--- a/src/utils/initialization.js
+++ b/src/utils/initialization.js
@@ -60,7 +60,7 @@ Now, let's get started!\n`)
   // TEMPLATE SELECTION
   template = template || await promptSelect('Which template would you like to use?', [
     'adobe-commerce/adobe-demo-store', // ACCS template
-    'adobe-commerce/ccdm-demo-store', // ACO template
+    // 'adobe-commerce/ccdm-demo-store', // ACO template
     'hlxsites/aem-boilerplate-commerce' // template
     // 'adobe-rnd/aem-boilerplate-xcom' // UE Template
     // 'aabsites/citisignal' // TODO: Cannot use citisignal until we resolve how to use templates that use config service as some core files are missing https://magento.slack.com/archives/C085R48U3R7/p1738785011567519

--- a/src/utils/runCommand.js
+++ b/src/utils/runCommand.js
@@ -10,8 +10,11 @@ const aioLogger = Logger('commerce:runCommand.js')
 export async function runCommand (command) {
   try {
     const { stdout, stderr } = await execPromise(command)
+    aioLogger.debug('stdout:', stdout)
+    aioLogger.debug('stderr:', stderr)
     return { stdout, stderr }
   } catch (error) {
-    aioLogger.debug(`Execution error: ${error}`)
+    aioLogger.debug(error)
+    throw error
   }
 }


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/USF-2321

https://magento.slack.com/archives/C08PG2TTWTC/p1747406431682419

The runCommand was catching/hiding errors. re-throwing the errors caused github repo creation to fail because the initial existence check throws if not exist.

So now, we always throw errors from runCommand, AND we properly catch the initial case where a non-existent repo is intended.

Note - I added another check, for org access, but it requires additional scopes so commented it out for now.

You can test this with the following scenarios using `aio commerce init`:

1) Try with org/repo that you dont own and doesn't exist, ie example/example
2) Try with org that exists but you dont have permission to write, ie virattt/ai-hedge-fund (currently the top of the github "explore" view)
3) Try with org you have permission to, but with site that exists, ie yourusername/existingrepo
4) Try with org you have permission to, but site that does not exist (ie yourusername/newrepo)

1-3 should fail, and 4 should work.