### PR TITLE
feat: Add ACCS instance selection to AEM Boilerplate Commerce setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `@adobe/aio-cli-plugin-commerce` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-03-16
+
+### Added
+
+- ACCS Commerce instance selection during AEM Boilerplate Commerce setup in `app-setup`, writing the selected endpoint into the project's `config.json`
+- `ensureConsoleOrg()` in `consoleSetup` for org-only selection (AEM Boilerplate does not need project/workspace)
+
+### Changed
+
+- Restructured `app-setup` to collect all interactive prompts (org, ACCS instance) before cloning and installing, so users answer all questions upfront
+
 ## [0.7.2] - 2026-03-17
 
 ### Fixed
@@ -141,7 +152,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for multiple templates (Adobe Demo Store, CitiSignal)
 - Flags for non-interactive setup (`--skipGit`, `--datasource`, `--org`, `--repo`, etc.)
 
-[Unreleased]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.2...HEAD
+[Unreleased]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.2...0.8.0
 [0.7.2]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/v0.5.0-beta.1...0.7.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-commerce",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "dependencies": {
     "@adobe/aio-cli-lib-console": "^5.0.1",
     "@adobe/aio-lib-core-config": "^5",

--- a/src/commands/commerce/extensibility/app-setup.js
+++ b/src/commands/commerce/extensibility/app-setup.js
@@ -15,11 +15,13 @@ import Logger from '@adobe/aio-lib-core-logging'
 import STARTER_KITS from '../../../configs/starterKits.json' with { type: 'json' }
 import agentsConfig from '../../../configs/agents.json' with { type: 'json' }
 import { verifyLoggedIn } from '../../../utils/extensibility/app-setup/loginCheck.js'
-import { ensureConsoleConfig } from '../../../utils/extensibility/app-setup/consoleSetup.js'
+import { ensureConsoleConfig, ensureConsoleOrg } from '../../../utils/extensibility/app-setup/consoleSetup.js'
 import { ensureWorkspaceCredentials } from '../../../utils/extensibility/app-setup/ensureWorkspaceCredentials.js'
 import { cloneAndInstall } from '../../../utils/extensibility/app-setup/cloneAndInstall.js'
 import { runIntegrationSetup } from '../../../utils/extensibility/app-setup/integrationSetup.js'
 import { runCheckoutSetup } from '../../../utils/extensibility/app-setup/checkoutSetup.js'
+import { runBoilerplateSetup } from '../../../utils/extensibility/app-setup/boilerplateSetup.js'
+import { getCommerceGraphQLUrl } from '../../../utils/extensibility/app-setup/commerceInstance.js'
 import { runToolsSetup } from '../../../utils/extensibility/app-setup/runToolsSetup.js'
 
 const aioLogger = Logger('commerce:app-setup.js')
@@ -85,6 +87,25 @@ export class AppSetupCommand extends Command {
         )
       }
 
+      const isIntegrationOrCheckout =
+        selectedStarterKit.folder === 'integration-starter-kit' ||
+        selectedStarterKit.folder === 'checkout-starter-kit'
+      const isBoilerplate =
+        selectedStarterKit.folder === 'aem-boilerplate-commerce'
+
+      // Console & instance prompts before clone so all questions are asked upfront
+      let commerceGraphQLUrl
+      if (isBoilerplate) {
+        currentStep = 'console setup'
+        await ensureConsoleOrg()
+
+        currentStep = 'commerce instance selection'
+        commerceGraphQLUrl = await getCommerceGraphQLUrl()
+      } else if (isIntegrationOrCheckout) {
+        currentStep = 'console setup'
+        await ensureConsoleConfig()
+      }
+
       currentStep = 'clone and install'
       const { projectDir, packageManager } = await cloneAndInstall(
         selectedStarterKit,
@@ -93,23 +114,18 @@ export class AppSetupCommand extends Command {
         flags['package-manager'] || null
       )
 
-      const isIntegrationOrCheckout =
-        selectedStarterKit.folder === 'integration-starter-kit' ||
-        selectedStarterKit.folder === 'checkout-starter-kit'
-
       if (isIntegrationOrCheckout) {
-        currentStep = 'console setup'
-        await ensureConsoleConfig()
-
         currentStep = 'workspace credentials'
         await ensureWorkspaceCredentials()
+      }
 
-        currentStep = 'kit-specific setup'
-        if (selectedStarterKit.folder === 'integration-starter-kit') {
-          await runIntegrationSetup(projectDir)
-        } else {
-          await runCheckoutSetup(projectDir)
-        }
+      currentStep = 'kit-specific setup'
+      if (selectedStarterKit.folder === 'integration-starter-kit') {
+        await runIntegrationSetup(projectDir)
+      } else if (selectedStarterKit.folder === 'checkout-starter-kit') {
+        await runCheckoutSetup(projectDir)
+      } else if (isBoilerplate) {
+        await runBoilerplateSetup(projectDir, commerceGraphQLUrl)
       }
 
       currentStep = 'tools setup'

--- a/src/utils/extensibility/app-setup/boilerplateSetup.js
+++ b/src/utils/extensibility/app-setup/boilerplateSetup.js
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import fs from 'fs'
+import path from 'path'
+import Logger from '@adobe/aio-lib-core-logging'
+
+const aioLogger = Logger('commerce:app-setup:boilerplateSetup.js')
+
+const DEFAULT_CONFIG = {
+  public: {
+    default: {
+      'commerce-core-endpoint': '',
+      'commerce-endpoint': '',
+      headers: {
+        cs: {
+          'Magento-Customer-Group': 'b6589fc6ab0dc82cf12099d1c2d40ab994e8410c',
+          'Magento-Store-Code': 'main_website_store',
+          'Magento-Store-View-Code': 'default',
+          'Magento-Website-Code': 'base',
+          'x-api-key': '',
+          'Magento-Environment-Id': ''
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Writes the Commerce endpoint into the project's config.json.
+ * The Commerce URL should be collected before cloning so all prompts happen upfront.
+ *
+ * @param {string} projectDir - Project root directory
+ * @param {string} graphqlUrl - Commerce GraphQL endpoint URL (already collected)
+ */
+export async function runBoilerplateSetup (projectDir, graphqlUrl) {
+  console.log('\n📋 Configuring AEM Boilerplate Commerce...')
+
+  const configPath = path.join(projectDir, 'config.json')
+  let configData
+
+  if (fs.existsSync(configPath)) {
+    try {
+      configData = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+    } catch {
+      console.log('   ⚠ Existing config.json could not be parsed. Creating a new one.')
+      configData = structuredClone(DEFAULT_CONFIG)
+    }
+  } else {
+    configData = structuredClone(DEFAULT_CONFIG)
+  }
+
+  if (!configData.public) configData.public = {}
+  if (!configData.public.default) configData.public.default = {}
+
+  configData.public.default['commerce-core-endpoint'] = graphqlUrl
+  configData.public.default['commerce-endpoint'] = graphqlUrl
+
+  fs.writeFileSync(configPath, JSON.stringify(configData, null, 2) + '\n')
+  console.log('   ✔ Commerce instance configured in config.json')
+
+  aioLogger.debug('Wrote commerce endpoints to config.json', { graphqlUrl, configPath })
+}

--- a/src/utils/extensibility/app-setup/consoleSetup.js
+++ b/src/utils/extensibility/app-setup/consoleSetup.js
@@ -17,6 +17,52 @@ import Logger from '@adobe/aio-lib-core-logging'
 const aioLogger = Logger('commerce:app-setup:consoleSetup.js')
 
 /**
+ * Ensures an org is selected in the aio console config.
+ * If already set, displays it and asks if the user wants to continue or reselect.
+ * Only prompts for org — does not touch project or workspace.
+ *
+ * @returns {Promise<void>}
+ */
+export async function ensureConsoleOrg () {
+  const org = config.get('console.org')
+
+  if (org) {
+    const orgId = org.id ?? org.code
+
+    console.log('\n📋 Current Adobe I/O Console organization:')
+    console.log(`   Org: ${org.name ?? 'Unknown'} (${orgId ?? 'Unknown'})`)
+
+    const continueWithCurrent = await promptConfirm(
+      'Do you want to continue with this organization? (Answer "No" to select a different org)'
+    )
+
+    if (continueWithCurrent) {
+      aioLogger.debug('User chose to continue with existing console org')
+      return
+    }
+
+    aioLogger.debug('User chose to reselect org')
+    config.delete('console.org')
+  }
+
+  console.log('\n🔧 Selecting Adobe I/O Console organization...\n')
+
+  await runInteractiveCommand('aio console org select')
+
+  config.reload()
+
+  const selectedOrg = config.get('console.org')
+  if (!selectedOrg) {
+    throw new Error(
+      'Console org must be selected. Run `aio console org select` first.'
+    )
+  }
+
+  console.log('\n✅ Organization configured:')
+  console.log(`   Org: ${selectedOrg.name ?? 'Unknown'}`)
+}
+
+/**
  * Ensures org, project, and workspace are selected in the aio console config.
  * If already set, displays them and asks if the user wants to continue or reselect.
  * If user reselects, clears config and runs interactive aio console selection commands.


### PR DESCRIPTION
## Summary

- Added ACCS Commerce instance selection during AEM Boilerplate Commerce `app-setup`, writing the selected endpoint into the project's `config.json`
- Added `ensureConsoleOrg()` for org-only console selection (AEM Boilerplate does not need project/workspace)
- Restructured `app-setup` to collect all interactive prompts (org, ACCS instance) before cloning and installing

## Test plan

- [ ] Run `aio commerce extensibility app-setup` with AEM Boilerplate Commerce and verify org selection + ACCS instance prompt appear before clone
- [ ] Verify selected Commerce URL is written to `config.json` in the cloned project
- [ ] Run `app-setup` with Integration/Checkout starter kits and verify existing flow is unchanged (full org/project/workspace selection)


Made with [Cursor](https://cursor.com)