### PR TITLE
feat: add --instance and --instance-name flags to app-setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `@adobe/aio-cli-plugin-commerce` will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-14
+
+### Added
+
+- New `--instance` (`-i`) flag for `app-setup` to provide a Commerce GraphQL endpoint URL directly, skipping interactive instance selection
+- New `--instance-name` (`-I`) flag for `app-setup` to select a Commerce instance by name from the available instances (case-insensitive match); falls back to interactive selection with the available list if no match is found
+- The two flags are mutually exclusive — providing both results in an error
+
+### Changed
+
+- Refactored `accs.js` to extract shared `fetchTenants()` and `saveAdminUrl()` helpers, reused by both `getAndSelectInstances()` and the new `findInstanceByName()`
+- Updated `runIntegrationSetup()` and `runCheckoutSetup()` to accept and forward instance options, so `--instance` and `--instance-name` flags work for all three starter kits (integration, checkout, and boilerplate)
+
 ## [0.8.0] - 2026-03-16
 
 ### Added
@@ -152,7 +165,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for multiple templates (Adobe Demo Store, CitiSignal)
 - Flags for non-interactive setup (`--skipGit`, `--datasource`, `--org`, `--repo`, etc.)
 
-[Unreleased]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.8.0...HEAD
+[Unreleased]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.9.0...HEAD
+[0.9.0]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.2...0.8.0
 [0.7.2]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/adobe-commerce/aio-cli-plugin-commerce/compare/0.7.0...0.7.1

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ $ aio plugins:install https://github.com/adobe-commerce/aio-cli-plugin-commerce#
 ```
 USAGE
   $ aio commerce extensibility app-setup [-s <value>] [-n <value>] [-a <value>] [-p npm|yarn] [-v <value>] [-f]
+    [-i <value>] [-I <value>]
 
 FLAGS
   -s, --starter-kit=<value>      Starter kit folder (e.g. integration-starter-kit, checkout-starter-kit, aem-boilerplate-commerce)
@@ -128,6 +129,8 @@ FLAGS
   -p, --package-manager=<option> Package manager: npm or yarn
   -v, --tools-version=<value>    Version of commerce-extensibility-tools to install (default: latest)
   -f, --force                    Force overwrite of existing MCP configuration in tools-setup
+  -i, --instance=<value>         Commerce GraphQL endpoint URL (mutually exclusive with --instance-name)
+  -I, --instance-name=<value>    Commerce instance name to select from available instances (mutually exclusive with --instance)
 
 DESCRIPTION
   Setup your Commerce Extensibility app: clone starter kit, configure aio console,
@@ -138,6 +141,8 @@ EXAMPLES
   $ aio commerce extensibility app-setup --starter-kit integration-starter-kit --project-name my-app --agent Cursor
   $ aio commerce extensibility app-setup -s checkout-starter-kit -n checkout-app -a Cursor -p npm
   $ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor
+  $ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor --instance https://example.api.commerce.adobe.com/tenant/graphql
+  $ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor --instance-name "My Commerce Instance"
 ```
 
 This command automates the full project setup workflow for Commerce Extensibility. It runs the following steps:
@@ -153,6 +158,18 @@ This command automates the full project setup workflow for Commerce Extensibilit
 9. **Tools setup** — runs `tools-setup` to install Commerce Extensibility MCP tools and agent skills
 
 All flags are optional. When omitted, the command prompts interactively. When all flags are provided, the command runs non-interactively.
+
+### Commerce Instance Selection (Boilerplate only)
+
+For the `aem-boilerplate-commerce` starter kit, the command needs a Commerce GraphQL endpoint URL. You can provide it in three ways:
+
+| Method | Flag | Behavior |
+|--------|------|----------|
+| Direct URL | `--instance` | Uses the provided URL directly (no API lookup) |
+| By name | `--instance-name` | Looks up the instance by name from available instances (case-insensitive match). If no match is found, displays the available instances and falls back to interactive selection |
+| Interactive | _(neither flag)_ | Fetches available instances and prompts you to select one |
+
+The `--instance` and `--instance-name` flags are **mutually exclusive** — providing both will result in an error.
 
 ## `aio commerce init`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-commerce",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "dependencies": {
     "@adobe/aio-cli-lib-console": "^5.0.1",
     "@adobe/aio-lib-core-config": "^5",

--- a/src/commands/commerce/extensibility/app-setup.js
+++ b/src/commands/commerce/extensibility/app-setup.js
@@ -100,7 +100,10 @@ export class AppSetupCommand extends Command {
         await ensureConsoleOrg()
 
         currentStep = 'commerce instance selection'
-        commerceGraphQLUrl = await getCommerceGraphQLUrl()
+        commerceGraphQLUrl = await getCommerceGraphQLUrl({
+          instanceUrl: flags.instance,
+          instanceName: flags['instance-name']
+        })
       } else if (isIntegrationOrCheckout) {
         currentStep = 'console setup'
         await ensureConsoleConfig()
@@ -119,11 +122,16 @@ export class AppSetupCommand extends Command {
         await ensureWorkspaceCredentials()
       }
 
+      const instanceOptions = {
+        instanceUrl: flags.instance,
+        instanceName: flags['instance-name']
+      }
+
       currentStep = 'kit-specific setup'
       if (selectedStarterKit.folder === 'integration-starter-kit') {
-        await runIntegrationSetup(projectDir)
+        await runIntegrationSetup(projectDir, instanceOptions)
       } else if (selectedStarterKit.folder === 'checkout-starter-kit') {
-        await runCheckoutSetup(projectDir)
+        await runCheckoutSetup(projectDir, instanceOptions)
       } else if (isBoilerplate) {
         await runBoilerplateSetup(projectDir, commerceGraphQLUrl)
       }
@@ -186,6 +194,18 @@ AppSetupCommand.flags = {
     char: 'f',
     description: 'Force overwrite of existing MCP configuration in tools-setup',
     default: false
+  }),
+  instance: Flags.string({
+    char: 'i',
+    description: 'Commerce GraphQL endpoint URL (mutually exclusive with --instance-name)',
+    required: false,
+    exclusive: ['instance-name']
+  }),
+  'instance-name': Flags.string({
+    char: 'I',
+    description: 'Commerce instance name to select from available instances (mutually exclusive with --instance)',
+    required: false,
+    exclusive: ['instance']
   })
 }
 
@@ -195,5 +215,7 @@ AppSetupCommand.examples = [
   '$ aio commerce extensibility app-setup',
   '$ aio commerce extensibility app-setup --starter-kit integration-starter-kit --project-name my-app --agent Cursor',
   '$ aio commerce extensibility app-setup -s checkout-starter-kit -n checkout-app -a Cursor -p npm',
-  '$ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor'
+  '$ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor',
+  '$ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor --instance https://example.api.commerce.adobe.com/tenant/graphql',
+  '$ aio commerce extensibility app-setup -s aem-boilerplate-commerce -n storefront -a Cursor --instance-name "My Commerce Instance"'
 ]

--- a/src/utils/accs.js
+++ b/src/utils/accs.js
@@ -10,24 +10,23 @@ const { CCM_BASE_URL } = CONSTANTS
 const urlPattern = /https:\/\/[^\s]+/g
 
 /**
- * Fetches Commerce instances from the Tenant API for the current IMS Org
- * and prompts the user to select one.
+ * Fetches Commerce tenants from the Tenant API for the current IMS Org.
  *
- * @returns {Promise<string>} The selected Commerce GraphQL endpoint URL
+ * @returns {Promise<{tenants: Array, orgName: string}>}
  * @throws {Error} When the API is unavailable, auth fails, or no instances are found
  */
-export async function getAndSelectInstances () {
+async function fetchTenants () {
   const consoleOrg = config.get('console.org')
   if (!consoleOrg) {
     throw new Error('No org selected. Run `aio console org select` first.')
   }
   const IMS_ORG = consoleOrg.code ?? consoleOrg.id ?? consoleOrg.ims_org_id
-  const name = consoleOrg.name
+  const orgName = consoleOrg.name
   if (!IMS_ORG) {
     throw new Error('Console org config is missing org identifier (code/id). Try reselecting org with `aio console org select`.')
   }
 
-  aioLogger.debug(`Looking up available tenants in the "${name}" IMS Organization`)
+  aioLogger.debug(`Looking up available tenants in the "${orgName}" IMS Organization`)
 
   await ims.context.setCurrent('cli')
   const token = await ims.getToken('cli')
@@ -45,8 +44,34 @@ export async function getAndSelectInstances () {
 
   const tenants = resp?.tenants ?? []
   if (tenants.length === 0) {
-    throw new Error(`No Commerce instances found for org "${name}".`)
+    throw new Error(`No Commerce instances found for org "${orgName}".`)
   }
+
+  return { tenants, orgName }
+}
+
+/**
+ * Saves the admin URL for the chosen tenant to config.
+ */
+function saveAdminUrl (tenant) {
+  try {
+    if (tenant?.serviceURLs?.admin) {
+      config.set('commerce.datasource.admin', tenant.serviceURLs.admin)
+    }
+  } catch (e) {
+    aioLogger.debug('unable to get admin url')
+  }
+}
+
+/**
+ * Fetches Commerce instances from the Tenant API for the current IMS Org
+ * and prompts the user to select one.
+ *
+ * @returns {Promise<string>} The selected Commerce GraphQL endpoint URL
+ * @throws {Error} When the API is unavailable, auth fails, or no instances are found
+ */
+export async function getAndSelectInstances () {
+  const { tenants } = await fetchTenants()
 
   const choices = tenants.map(tenant => `${tenant.name}: ${tenant.serviceURLs.graphQL}`)
 
@@ -57,13 +82,49 @@ export async function getAndSelectInstances () {
   const urlMatch = choice.match(urlPattern)
   aioLogger.debug('selected', urlMatch[0])
 
-  try {
-    const chosen = tenants.find(tenant => tenant.serviceURLs.graphQL === urlMatch[0])
-    if (chosen) {
-      config.set('commerce.datasource.admin', chosen.serviceURLs.admin)
-    }
-  } catch (e) {
-    aioLogger.debug('unable to get admin url')
+  const chosen = tenants.find(tenant => tenant.serviceURLs.graphQL === urlMatch[0])
+  saveAdminUrl(chosen)
+  return urlMatch[0]
+}
+
+/**
+ * Finds a Commerce instance by name. If no exact match is found (case-insensitive),
+ * displays the available instances and falls back to interactive selection.
+ *
+ * @param {string} instanceName - The instance name to search for
+ * @returns {Promise<string>} The Commerce GraphQL endpoint URL
+ * @throws {Error} When the API is unavailable, auth fails, or no instances are found
+ */
+export async function findInstanceByName (instanceName) {
+  const { tenants } = await fetchTenants()
+
+  const match = tenants.find(
+    tenant => tenant.name.toLowerCase() === instanceName.toLowerCase()
+  )
+
+  if (match) {
+    const url = match.serviceURLs.graphQL
+    console.log(`Using Commerce instance "${match.name}": ${url}`)
+    saveAdminUrl(match)
+    return url
   }
+
+  const availableNames = tenants.map(t => t.name).join(', ')
+  console.log(
+    `\n   ⚠️  No Commerce instance found matching "${instanceName}".` +
+    `\n      Available instances: ${availableNames}` +
+    '\n      Please select from the list below.\n'
+  )
+
+  const choices = tenants.map(tenant => `${tenant.name}: ${tenant.serviceURLs.graphQL}`)
+  const choice = await promptSelect(
+    'Select Commerce instance (type to search)',
+    choices
+  )
+  const urlMatch = choice.match(urlPattern)
+  aioLogger.debug('selected', urlMatch[0])
+
+  const chosen = tenants.find(tenant => tenant.serviceURLs.graphQL === urlMatch[0])
+  saveAdminUrl(chosen)
   return urlMatch[0]
 }

--- a/src/utils/extensibility/app-setup/checkoutSetup.js
+++ b/src/utils/extensibility/app-setup/checkoutSetup.js
@@ -26,8 +26,9 @@ import { createSpinner } from '../../spinner.js'
  * Runs Checkout Starter Kit-specific setup steps.
  *
  * @param {string} projectDir - Project root directory
+ * @param {object} [instanceOptions={}] - Commerce instance options (--instance / --instance-name flags)
  */
-export async function runCheckoutSetup (projectDir) {
+export async function runCheckoutSetup (projectDir, instanceOptions = {}) {
   console.log('\n📋 Configuring Checkout Starter Kit...')
 
   const envDistPath = path.join(projectDir, 'env.dist')
@@ -42,7 +43,7 @@ export async function runCheckoutSetup (projectDir) {
   console.log('   Creating .env from env.dist...')
   copyEnvFile(envDistPath, envPath)
 
-  const graphqlUrl = await getCommerceGraphQLUrl()
+  const graphqlUrl = await getCommerceGraphQLUrl(instanceOptions)
   let baseUrl = graphqlUrl.replace(/\/graphql\/?$/, '')
   if (!baseUrl.endsWith('/')) {
     baseUrl += '/'

--- a/src/utils/extensibility/app-setup/commerceInstance.js
+++ b/src/utils/extensibility/app-setup/commerceInstance.js
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { getAndSelectInstances } from '../../accs.js'
+import { getAndSelectInstances, findInstanceByName } from '../../accs.js'
 import { promptInput } from '../../prompt.js'
 import Logger from '@adobe/aio-lib-core-logging'
 
@@ -33,12 +33,30 @@ function normalizeGraphQLUrl (input) {
 
 /**
  * Gets the Commerce GraphQL endpoint URL.
- * First attempts to fetch and select from the tenant API.
- * If that fails, prompts the user to enter the URL manually.
  *
+ * When `instanceUrl` is provided, normalizes and returns it directly.
+ * When `instanceName` is provided, looks up the instance by name from the tenant API.
+ * Otherwise falls back to the interactive selection flow.
+ *
+ * @param {object} [options={}]
+ * @param {string} [options.instanceUrl] - Direct Commerce GraphQL URL (--instance flag)
+ * @param {string} [options.instanceName] - Instance name to look up (--instance-name flag)
  * @returns {Promise<string>} The GraphQL endpoint URL
  */
-export async function getCommerceGraphQLUrl () {
+export async function getCommerceGraphQLUrl ({ instanceUrl, instanceName } = {}) {
+  if (instanceUrl) {
+    const normalized = normalizeGraphQLUrl(instanceUrl)
+    if (!normalized) {
+      throw new Error('Invalid --instance URL. Please provide a valid Commerce GraphQL endpoint URL.')
+    }
+    console.log(`Using Commerce instance URL: ${normalized}`)
+    return normalized
+  }
+
+  if (instanceName) {
+    return findInstanceByName(instanceName)
+  }
+
   try {
     const url = await getAndSelectInstances()
     if (url) {

--- a/src/utils/extensibility/app-setup/integrationSetup.js
+++ b/src/utils/extensibility/app-setup/integrationSetup.js
@@ -26,8 +26,9 @@ import { createSpinner } from '../../spinner.js'
  * Runs Integration Starter Kit-specific setup steps.
  *
  * @param {string} projectDir - Project root directory
+ * @param {object} [instanceOptions={}] - Commerce instance options (--instance / --instance-name flags)
  */
-export async function runIntegrationSetup (projectDir) {
+export async function runIntegrationSetup (projectDir, instanceOptions = {}) {
   console.log('\n📋 Configuring Integration Starter Kit...')
 
   const envDistPath = path.join(projectDir, 'env.dist')
@@ -42,7 +43,7 @@ export async function runIntegrationSetup (projectDir) {
   console.log('   Creating .env from env.dist...')
   copyEnvFile(envDistPath, envPath)
 
-  const graphqlUrl = await getCommerceGraphQLUrl()
+  const graphqlUrl = await getCommerceGraphQLUrl(instanceOptions)
   let baseUrl = graphqlUrl.replace(/\/graphql\/?$/, '')
   if (!baseUrl.endsWith('/')) {
     baseUrl += '/'


### PR DESCRIPTION
## Summary

- Adds `--instance` (`-i`) flag to provide a Commerce GraphQL endpoint URL directly, skipping interactive instance selection
- Adds `--instance-name` (`-I`) flag to select a Commerce instance by name (case-insensitive match) from available instances; falls back to interactive selection with the available list if no match is found
- The two flags are mutually exclusive (enforced by oclif's `exclusive` property) — providing both results in an error
- Fixes instance flag passthrough for integration and checkout starter kits by forwarding `instanceOptions` through `runIntegrationSetup()` and `runCheckoutSetup()` to `getCommerceGraphQLUrl()`
- Refactors `accs.js` to extract shared `fetchTenants()` and `saveAdminUrl()` helpers
- Updates README and CHANGELOG for v0.9.0

## Test plan

- [ ] Run `aio commerce extensibility app-setup -s integration-starter-kit -n test -a Cursor --instance-name "L320-098"` — should auto-select the instance without prompting
- [ ] Run `aio commerce extensibility app-setup -s checkout-starter-kit -n test -a Cursor --instance-name "L320-098"` — should auto-select the instance without prompting
- [ ] Run `aio commerce extensibility app-setup -s aem-boilerplate-commerce -n test -a Cursor --instance-name "L320-098"` — should auto-select the instance without prompting
- [ ] Run with `--instance https://example.com/graphql` — should use URL directly without API lookup
- [ ] Run with both `--instance` and `--instance-name` — should error with mutual exclusivity message
- [ ] Run with `--instance-name "nonexistent"` — should show available instances and fall back to interactive selection
- [ ] Run without either flag — should behave as before (interactive selection)


Made with [Cursor](https://cursor.com)